### PR TITLE
Implement all the constraints for the dashboard (via a little DSL for constraints)

### DIFF
--- a/ConstraintSyntaxTrees.py
+++ b/ConstraintSyntaxTrees.py
@@ -136,6 +136,13 @@ class Expr:
               return str(self.value)
         return f"({self.value.toLatex()} {self.op} {self.right.toLatex()})"
 
+# Helper
+def var(name : str) -> Expr:
+    """
+    Create a variable expression
+    """
+    return Expr(name)
+
 # Print the constraints, for checking purposes
 def print_constraints(constraints : list[Constraint]):
     for constraint in constraints:

--- a/ConstraintSyntaxTrees.py
+++ b/ConstraintSyntaxTrees.py
@@ -1,0 +1,179 @@
+
+"""
+This module defines a simple constraint syntax tree that can be used to
+represent constraints in a linear program. The syntax tree is made up of
+two classes: Expr and Constraint. An Expr object represents an expression
+in the constraint, while a Constraint object represents a constraint in
+the linear program. The Expr class has methods for evaluating the expression
+using a model, and for returning a list of variables in the expression. The
+Constraint class has methods for checking if the constraint is satisfied by
+a model, and for balancing the constraint using a model. The Expr class
+overloads the +, *, and <= operators to allow for easy construction of
+expressions and constraints.
+
+The right hand side of the constraint is always a float, while the left hand
+side is an expression. The expression can be a constant, a variable, or an
+operation on other expressions. The expression can be evaluated using a model
+to get a float value, and the variables in the expression can be returned as
+a list of strings. The constraint can be checked for satisfaction using a
+model, and the constraint can be balanced using a model to get a new model
+that satisfies the constraint.
+"""
+from typing import Dict, Callable
+
+class Constraint:
+  """
+  Represention of a linear constraint with an expression on the left
+   and a float on the right. The constraint can be checked for satisfaction
+   using a model, and can be balanced using a model to get a new model that
+   satisfies the constraint.
+  """
+  def __init__(self, left, right : float):
+    self.left = left
+    self.right = right
+
+  def isSatisfied(self, model : Dict[str, float]) -> bool:
+    """
+    Evaluate the constraint on a set of data
+    """
+    return (self.left.eval(model) <= self.right)
+
+  def balance(self, model : Dict[str, float]) -> Dict[str, float]:
+    """
+    Use the constraint to balance a model
+    """
+    model_out = model.copy()
+    # For every var in the constraint expression
+    for var in self.left.getVars():
+      # Scale the variable by the ratio of the right hand side
+      # to the left hand side
+      model_out[var] = model[var] / (self.left.eval(model) * self.right)
+    return model_out
+
+  def __repr__(self):
+    """
+    Return a string representation of the constraint
+    """
+    return f"{self.left} <= {self.right}"
+
+  def toLatex(self):
+    """
+    Return a LaTeX representation of the constraint
+    """
+    return f"{self.left.toLatex()} \\leq {self.right}"
+
+class Expr:
+    def __init__(self, value, op=None, right=None):
+        self.value = value
+        self.op = op
+        self.right = right
+
+    def eval(self, model : Dict[str, float]) -> float:
+      """
+      Evaluate the expression using the given model
+      """
+
+      # No operation so either a variable or float
+      if self.op is None:
+          # If a float constant, just return that otherwise look up in the model
+          return self.value if (type(self.value) == float) else model[self.value]
+      else:
+        # Evaluate the left and right
+        left = self.value.eval(model)
+        right = self.right.eval(model)
+        # Interpret the operation
+        if self.op == '+':
+            return left + right
+        elif self.op == '*':
+            return left * right
+        else:
+            raise ValueError(f"Unknown operator {self.op}")
+
+    # Magic methods to allow for easy construction of expressions
+    def __add__(self, other):
+        return Expr(self, '+', other if isinstance(other, Expr) else Expr(other))
+
+    def __radd__(self, other):
+        # this handles something like 2 + x
+        return Expr(Expr(other), '+', self)
+
+    def __mul__(self, other):
+        return Expr(self, '*', other if isinstance(other, Expr) else Expr(other))
+
+    def __rmul__(self, other):
+        # this handles something like 2 * x
+        return Expr(Expr(other), '*', self)
+
+    def __le__(self, other):
+        return Constraint(self, other)
+
+    def getVars(self):
+        """
+        Return a list of all the variables in the expression
+        """
+        if self.op is None and type(self.value) == str:
+            return [self.value]
+        left = self.value.getVars() if isinstance(self.value, Expr) else []
+        right = self.right.getVars() if isinstance(self.right, Expr) else []
+        return left + right
+
+    def __repr__(self):
+        """
+        Return a string representation of the expression
+        """
+        if self.op is None:
+            return str(self.value)
+        return f"({self.value} {self.op} {self.right})"
+
+    def toLatex(self):
+        """
+        Return a LaTeX representation of the expression
+        """
+        if self.op is None:
+            if type(self.value) == str:
+                # If the variable contains a '_' turn this
+                # into a subscript in LaTeX
+                if '_' in self.value:
+                    return self.value.replace('_', '_{') + '}'
+                else:
+                  return self.value
+            else:
+              return str(self.value)
+        return f"({self.value.toLatex()} {self.op} {self.right.toLatex()})"
+
+# Print the constraints, for checking purposes
+def print_constraints(constraints : list[Constraint]):
+    for constraint in constraints:
+        print(constraint)
+
+# Generate a LaTeX representation of the constraints in specification.tex
+def generateLatexSpecification(constraints : list[Constraint]):
+  """
+  Generate a LaTeX representation of a set of constraints
+  """
+  baseTemplateStart = """\\documentclass{article} \
+\\usepackage{amsmath} \
+\\begin{document} \
+\\begin{center}
+\\begin{align*}
+"""
+  baseTemplateEnd = """
+\\end{align*} \
+\\end{center} \
+\\end{document} \
+"""
+  # Generate the LaTeX for each constraint
+  latexConstraints = []
+  for constraint in constraints:
+      if type(constraint) == str:
+        latexConstraints.append("\\end{align*}" + constraint + "\n\n\\begin{align*}")
+      else:
+        latexConstraints.append(constraint.toLatex() + "\\\\")
+
+  # Join the constraints together
+  constraintsString = "".join(latexConstraints)
+  # Write the latex document to specification.tex
+  print("Writing LaTeX specification of constraints to specification.tex")
+  with open('specification.tex', 'w') as f:
+    f.write(baseTemplateStart + constraintsString + baseTemplateEnd)
+  return

--- a/ConstraintSyntaxTrees.py
+++ b/ConstraintSyntaxTrees.py
@@ -146,24 +146,25 @@ def generateLatexSpecification(constraints : list[Constraint]):
   """
   Generate a LaTeX representation of a set of constraints
   """
-  baseTemplateStart = """\\documentclass{article} \
-\\usepackage{amsmath} \
-\\begin{document} \
-\\begin{center}
+  baseTemplateStart = """\\documentclass{article} \n\
+\\usepackage{amsmath} \n\
+\\begin{document} \n\
+\\begin{center} \n\
 \\begin{align*}
 """
   baseTemplateEnd = """
-\\end{align*} \
-\\end{center} \
+\\end{align*} \n\
+\\end{center} \n\
 \\end{document} \
 """
   # Generate the LaTeX for each constraint
   latexConstraints = []
   for constraint in constraints:
       if type(constraint) == str:
-        latexConstraints.append("\\end{align*}" + constraint + "\n\n\\begin{align*}")
+        latexConstraints.append("\\end{align*}\n\n" + constraint + "\n\n\\begin{align*}\n")
       else:
-        latexConstraints.append(constraint.toLatex() + "\\\\")
+        spacing = "\\\\\n" if constraint != constraints[-1] else ""
+        latexConstraints.append(constraint.toLatex() + spacing)
 
   # Join the constraints together
   constraintsString = "".join(latexConstraints)

--- a/ConstraintSyntaxTrees.py
+++ b/ConstraintSyntaxTrees.py
@@ -4,20 +4,15 @@ This module defines a simple constraint syntax tree that can be used to
 represent constraints in a linear program. The syntax tree is made up of
 two classes: Expr and Constraint. An Expr object represents an expression
 in the constraint, while a Constraint object represents a constraint in
-the linear program. The Expr class has methods for evaluating the expression
-using a model, and for returning a list of variables in the expression. The
-Constraint class has methods for checking if the constraint is satisfied by
-a model, and for balancing the constraint using a model. The Expr class
-overloads the +, *, and <= operators to allow for easy construction of
-expressions and constraints.
+the linear program.
 
-The right hand side of the constraint is always a float, while the left hand
-side is an expression. The expression can be a constant, a variable, or an
-operation on other expressions. The expression can be evaluated using a model
-to get a float value, and the variables in the expression can be returned as
-a list of strings. The constraint can be checked for satisfaction using a
-model, and the constraint can be balanced using a model to get a new model
-that satisfies the constraint.
+The expression can be a constant, a variable, or an operation on other expressions.
+The Expr class has methods for evaluating the expression using a model, and it overloads
+the +, *, and <= operators to allow for easy construction of expressions and constraints.
+
+The Constraint class has methods for checking if the constraint is satisfied by
+a model, and for balancing a model using the constraint, to get a new model
+satisfying the constraint.
 """
 from typing import Dict, Callable
 

--- a/constraints.py
+++ b/constraints.py
@@ -3,31 +3,31 @@ from ConstraintSyntaxTrees import *
 # Representation of the MiniLUSP Optimisation constraints
 constraints = [
     "Lowland Peat Overlap Constraints"
-  , (0.0258 * Expr("P_lo") + Expr("G")) <= 1
-  , (0.0258 * Expr("P_lo") + Expr("O")) <= 1
+  , (0.0258 * var("P_lo") + var("G")) <= 1
+  , (0.0258 * var("P_lo") + var("O")) <= 1
 
   , "Silvoarable Overlap Constraints"
-  , (0.3647 * Expr("S_A") + Expr("G")) <= 1
-  , (0.3647 * Expr("S_A") + Expr("O")) <= 1
-  , (0.4619 * Expr("S_A") + Expr("WL")) <= 1
+  , (0.3647 * var("S_A") + var("G")) <= 1
+  , (0.3647 * var("S_A") + var("O")) <= 1
+  , (0.4619 * var("S_A") + var("WL")) <= 1
 
   , "Silvopastoral Overlap Constraints"
-  , 0.3856 * Expr("S_P") + Expr("G") <= 1
-  , 0.4883 * Expr("S_P") + Expr("WL") <= 1
-  , 0.3856 * Expr("S_P") + Expr("O") <= 1
-  , 0.8036 * Expr("S_P") + Expr("WP") <= 1
+  , 0.3856 * var("S_P") + var("G") <= 1
+  , 0.4883 * var("S_P") + var("WL") <= 1
+  , 0.3856 * var("S_P") + var("O") <= 1
+  , 0.8036 * var("S_P") + var("WP") <= 1
 
   , "Woodland Overlap Constraints"
-  , 0.7503 * Expr("WL") + Expr("G") <= 1
-  , 0.7503 * Expr("WL") + Expr("O") <= 1
-  , Expr("WL") + 0.7218 * Expr("WP") <= 1.0986
+  , 0.7503 * var("WL") + var("G") <= 1
+  , 0.7503 * var("WL") + var("O") <= 1
+  , var("WL") + 0.7218 * var("WP") <= 1.0986
 
   , "Wood Pasture Overlap Constraints"
-  , Expr("WP") + 1.3255 * Expr("G") <= 1.4433
-  , Expr("WP") + 1.3255 * Expr("O") <= 1.4433
+  , var("WP") + 1.3255 * var("G") <= 1.4433
+  , var("WP") + 1.3255 * var("O") <= 1.4433
 
   , "Grassland-Organic Overlap Constraints"
-  , Expr("G") + Expr("O") <= 1
+  , var("G") + var("O") <= 1
   ]
 
 # Uncomment me to generate LaTeX specification document when running the dashboard

--- a/constraints.py
+++ b/constraints.py
@@ -1,0 +1,34 @@
+from ConstraintSyntaxTrees import *
+
+# Representation of the MiniLUSP Optimisation constraints
+constraints = [
+    "Lowland Peat Overlap Constraints"
+  , (0.0258 * Expr("P_lo") + Expr("G")) <= 1
+  , (0.0258 * Expr("P_lo") + Expr("O")) <= 1
+
+  , "Silvoarable Overlap Constraints"
+  , (0.3647 * Expr("S_A") + Expr("G")) <= 1
+  , (0.3647 * Expr("S_A") + Expr("O")) <= 1
+  , (0.4619 * Expr("S_A") + Expr("WL")) <= 1
+
+  , "Silvopastoral Overlap Constraints"
+  , 0.3856 * Expr("S_P") + Expr("G") <= 1
+  , 0.4883 * Expr("S_P") + Expr("WL") <= 1
+  , 0.3856 * Expr("S_P") + Expr("O") <= 1
+  , 0.8036 * Expr("S_P") + Expr("WP") <= 1
+
+  , "Woodland Overlap Constraints"
+  , 0.7503 * Expr("WL") + Expr("G") <= 1
+  , 0.7503 * Expr("WL") + Expr("O") <= 1
+  , Expr("WL") + 0.7218 * Expr("WP") <= 1.0986
+
+  , "Wood Pasture Overlap Constraints"
+  , Expr("WP") + 1.3255 * Expr("G") <= 1.4433
+  , Expr("WP") + 1.3255 * Expr("O") <= 1.4433
+
+  , "Grassland-Organic Overlap Constraints"
+  , Expr("G") + Expr("O") <= 1
+  ]
+
+# Generate specification document
+generateLatexSpecification(constraints)

--- a/constraints.py
+++ b/constraints.py
@@ -31,4 +31,4 @@ constraints = [
   ]
 
 # Generate LaTeX specification document
-generateLatexSpecification(constraints)
+# generateLatexSpecification(constraints)

--- a/constraints.py
+++ b/constraints.py
@@ -30,5 +30,5 @@ constraints = [
   , Expr("G") + Expr("O") <= 1
   ]
 
-# Generate specification document
+# Generate LaTeX specification document
 generateLatexSpecification(constraints)

--- a/constraints.py
+++ b/constraints.py
@@ -30,5 +30,5 @@ constraints = [
   , Expr("G") + Expr("O") <= 1
   ]
 
-# Generate LaTeX specification document
+# Uncomment me to generate LaTeX specification document when running the dashboard
 # generateLatexSpecification(constraints)

--- a/dashboard.py
+++ b/dashboard.py
@@ -18,6 +18,7 @@ import dash_bootstrap_components as dbc
 from plotly.subplots import make_subplots
 import plotly.graph_objects as px
 
+# Constraints for the model are defined here
 from constraints import constraints
 
 ### Set plotting style parameters

--- a/dashboard.py
+++ b/dashboard.py
@@ -19,7 +19,7 @@ from plotly.subplots import make_subplots
 import plotly.graph_objects as px
 
 # Constraints for the model are defined here
-from constraints import constraints
+from constraints import constraints, Constraint
 
 ### Set plotting style parameters
 ma.textstyle()
@@ -174,7 +174,7 @@ def clamp_sum(g_val, o_val, p_lo, s_a, s_p, w_l, w_p):
              , "S_P": s_p, "WL": w_l, "WP": w_p}
     # Apply balancing of the constraints when constraints are not satisfied
     for constraint in constraints:
-        if not constraint.isSatisfied(model):
+        if isinstance(constraint, Constraint) and not constraint.isSatisfied(model):
             model = constraint.balance(model)
 
     # Return the balanced values back to the UI

--- a/dashboard.py
+++ b/dashboard.py
@@ -18,6 +18,7 @@ import dash_bootstrap_components as dbc
 from plotly.subplots import make_subplots
 import plotly.graph_objects as px
 
+from constraints import constraints
 
 ### Set plotting style parameters
 ma.textstyle()
@@ -44,44 +45,44 @@ app.layout = html.Div(
             dcc.Slider(min=0, max=1, step=0.0001, marks=slider_scale, value=0,
                           tooltip={'placement': 'bottom', 'always_visible': True},
                           updatemode='drag', id='grassland'),
-            
+
             html.Label('Organic Increase', className='slider_label'),
             dcc.Slider(min=0, max=1, step=0.0001, marks=slider_scale, value=0,
                           tooltip={'placement': 'bottom', 'always_visible': True},
                           updatemode='drag', id='organic'),
-            
+
             html.Label('Peatland (Lower) Increase', className='slider_label'),
             dcc.Slider(min=0, max=1, step=0.0001, marks=slider_scale, value=0,
                           tooltip={'placement': 'bottom', 'always_visible': True},
                           updatemode='drag', id='peatland_lo'),
-            
+
             html.Label('Peatland (Upper) Increase', className='slider_label'),
             dcc.Slider(min=0, max=1, step=0.0001, marks=slider_scale, value=0,
                           tooltip={'placement': 'bottom', 'always_visible': True},
                           updatemode='drag', id='peatland_up'),
-            
+
             html.Label('Silvoarable Increase', className='slider_label'),
             dcc.Slider(min=0, max=1, step=0.0001, marks=slider_scale, value=0,
                           tooltip={'placement': 'bottom', 'always_visible': True},
                           updatemode='drag', id='silvoa'),
-            
+
             html.Label('Silvopastoral Increase', className='slider_label'),
             dcc.Slider(min=0, max=1, step=0.0001, marks=slider_scale, value=0,
                           tooltip={'placement': 'bottom', 'always_visible': True},
                           updatemode='drag', id='silvop'),
-            
+
             html.Label('Woodland Increase', className='slider_label'),
             dcc.Slider(min=0, max=1, step=0.0001, marks=slider_scale, value=0,
                           tooltip={'placement': 'bottom', 'always_visible': True},
                           updatemode='drag', id='woodland'),
-            
+
             html.Label('Wood Pasture Increase', className='slider_label'),
             dcc.Slider(min=0, max=1, step=0.0001, marks=slider_scale, value=0,
                           tooltip={'placement': 'bottom', 'always_visible': True},
                           updatemode='drag', id='woodpa'),]),
             width={'size':6}),
-         
-         
+
+
          dbc.Col([html.Div(dcc.Graph(id='fig1',
                                      style={'height':'80vh'}))],
                  width={'size':2}),
@@ -131,7 +132,7 @@ def display_value(grassland, organic, peatland_lo, peatland_up,
                       title_font=dict(size=18, family='assets/fonts/GlacialIndifference-Bold.otf'),
                       tickfont=dict(size=18, family='assets/fonts/GlacialIndifference-Bold.otf'))
     fig1.update_layout(plot_bgcolor='white')
-    
+
     fig2 = vi.single_dumbell('Farmland productivity % change',
                              base[1], z[1], [-1, 1],
                              ['#8B424B','#CCA857','#7DB567'])
@@ -155,20 +156,28 @@ def display_value(grassland, organic, peatland_lo, peatland_up,
     fig3.update_layout(plot_bgcolor='white')
 
     return [fig1, fig2, fig3]
-    
-# Grassland and organic constraint
+
+# Enforce invariants on the sliders
 @app.callback(
-    [Output('grassland', 'value'), Output('organic', 'value')],
-    [Input('grassland', 'value'), Input('organic', 'value')]
-)
-def clamp_sum(g_val, o_val):
-    total = g_val + o_val
-    if total <= 1:
-      # No change needed
-      return g_val, o_val
-    else:
-      # Scale both values proportionally so their sum is 1
-      return g_val / total, o_val / total
+   # All the sliders
+    [Output('grassland', 'value'), Output('organic', 'value'), Output('peatland_lo', 'value')
+   , Output('silvoa', 'value'), Output('silvop', 'value'), Output('woodland', 'value')
+   , Output('woodpa', 'value')],
+    # All the sliders
+    [Input('grassland', 'value'), Input('organic', 'value'), Input('peatland_lo', 'value')
+    , Input('silvoa', 'value'), Input('silvop', 'value'),  Input('woodland', 'value')
+    , Input('woodpa', 'value')])
+def clamp_sum(g_val, o_val, p_lo, s_a, s_p, w_l, w_p):
+    # Put the values into a model dictionary
+    model = {"G": g_val, "O": o_val, "P_lo" : p_lo, "S_A": s_a
+             , "S_P": s_p, "WL": w_l, "WP": w_p}
+    # Apply balancing of the constraints when constraints are not satisfied
+    for constraint in constraints:
+        if not constraint.isSatisfied(model):
+            model = constraint.balance(model)
+
+    # Return the balanced values back to the UI
+    return (model["G"], model["O"], model["P_lo"], model["S_A"], model["S_P"], model["WL"], model["WP"])
 
 # def display_value(grassland, organic, peatland_lo, peatland_up,
 #                   silvoa, silvop, woodland, woodpa):
@@ -183,13 +192,13 @@ def clamp_sum(g_val, o_val):
 #     lst3 = 'Relative geometric change across 120 terrestrial \
 #             bird species populations : {}'.format(z[2])
 #     lst = [nl, lst1, nl, nl, lst2, nl, nl, lst3]
-    
+
 #     fig = make_subplots(rows=1, cols=3, shared_yaxes=False)
 #     fig.add_trace(px.Bar(x=['Change in net CO2e emissions'], y=[z[0]],
 #                          marker=dict(
 #                              color=[z[0]],
-#                              colorscale=[[0, '#7DB567'],   
-#                                          [0.5, '#CCA857'], 
+#                              colorscale=[[0, '#7DB567'],
+#                                          [0.5, '#CCA857'],
 #                                          [1.0, '#8B424B']],
 #                              cmin=-1.0,
 #                              cmax=1.0)
@@ -197,20 +206,20 @@ def clamp_sum(g_val, o_val):
 #     fig.add_trace(px.Bar(x=['Change in total farmland calorific production'],
 #                          y=[z[1]], marker=dict(
 #                              color=[z[1]],
-#                              colorscale=[[0, '#8B424B'],   
-#                                          [0.5, '#CCA857'], 
+#                              colorscale=[[0, '#8B424B'],
+#                                          [0.5, '#CCA857'],
 #                                          [1.0, '#7DB567']],
 #                              cmin=0.0,
 #                              cmax=1.0),
 #                          ), row=1, col=2)
-    
-    
-    
+
+
+
 #     fig.add_trace(px.Bar(x=['Geometric bird species population change'],
 #                          y=[z[2]], marker=dict(
 #                              color=[z[2]],
-#                              colorscale=[[0.0, '#8B424B'],   
-#                                          [0.5, '#CCA857'], 
+#                              colorscale=[[0.0, '#8B424B'],
+#                                          [0.5, '#CCA857'],
 #                                          [1.0, '#7DB567']],
 #                              cmin=0.95,
 #                              cmax=1.1),

--- a/dashboard.py
+++ b/dashboard.py
@@ -168,7 +168,7 @@ def display_value(grassland, organic, peatland_lo, peatland_up,
     [Input('grassland', 'value'), Input('organic', 'value'), Input('peatland_lo', 'value')
     , Input('silvoa', 'value'), Input('silvop', 'value'),  Input('woodland', 'value')
     , Input('woodpa', 'value')])
-def clamp_sum(g_val, o_val, p_lo, s_a, s_p, w_l, w_p):
+def enforce_slider_constraints(g_val, o_val, p_lo, s_a, s_p, w_l, w_p):
     # Put the values into a model dictionary
     model = {"G": g_val, "O": o_val, "P_lo" : p_lo, "S_A": s_a
              , "S_P": s_p, "WL": w_l, "WP": w_p}

--- a/specification.tex
+++ b/specification.tex
@@ -1,16 +1,53 @@
-\documentclass{article} \usepackage{amsmath} \begin{document} \begin{center}
+\documentclass{article} 
+\usepackage{amsmath} 
+\begin{document} 
+\begin{center} 
 \begin{align*}
-\end{align*}Lowland Peat Overlap Constraints
+\end{align*}
 
-\begin{align*}((0.0258 * P_{lo}) + G) \leq 1\\((0.0258 * P_{lo}) + O) \leq 1\\\end{align*}Silvoarable Overlap Constraints
+Lowland Peat Overlap Constraints
 
-\begin{align*}((0.3647 * S_{A}) + G) \leq 1\\((0.3647 * S_{A}) + O) \leq 1\\((0.4619 * S_{A}) + WL) \leq 1\\\end{align*}Silvopastoral Overlap Constraints
+\begin{align*}
+((0.0258 * P_{lo}) + G) \leq 1\\
+((0.0258 * P_{lo}) + O) \leq 1\\
+\end{align*}
 
-\begin{align*}((0.3856 * S_{P}) + G) \leq 1\\((0.4883 * S_{P}) + WL) \leq 1\\((0.3856 * S_{P}) + O) \leq 1\\((0.8036 * S_{P}) + WP) \leq 1\\\end{align*}Woodland Overlap Constraints
+Silvoarable Overlap Constraints
 
-\begin{align*}((0.7503 * WL) + G) \leq 1\\((0.7503 * WL) + O) \leq 1\\(WL + (0.7218 * WP)) \leq 1.0986\\\end{align*}Wood Pasture Overlap Constraints
+\begin{align*}
+((0.3647 * S_{A}) + G) \leq 1\\
+((0.3647 * S_{A}) + O) \leq 1\\
+((0.4619 * S_{A}) + WL) \leq 1\\
+\end{align*}
 
-\begin{align*}(WP + (1.3255 * G)) \leq 1.4433\\(WP + (1.3255 * O)) \leq 1.4433\\\end{align*}Grassland-Organic Overlap Constraints
+Silvopastoral Overlap Constraints
 
-\begin{align*}(G + O) \leq 1\\
-\end{align*} \end{center} \end{document} 
+\begin{align*}
+((0.3856 * S_{P}) + G) \leq 1\\
+((0.4883 * S_{P}) + WL) \leq 1\\
+((0.3856 * S_{P}) + O) \leq 1\\
+((0.8036 * S_{P}) + WP) \leq 1\\
+\end{align*}
+
+Woodland Overlap Constraints
+
+\begin{align*}
+((0.7503 * WL) + G) \leq 1\\
+((0.7503 * WL) + O) \leq 1\\
+(WL + (0.7218 * WP)) \leq 1.0986\\
+\end{align*}
+
+Wood Pasture Overlap Constraints
+
+\begin{align*}
+(WP + (1.3255 * G)) \leq 1.4433\\
+(WP + (1.3255 * O)) \leq 1.4433\\
+\end{align*}
+
+Grassland-Organic Overlap Constraints
+
+\begin{align*}
+(G + O) \leq 1
+\end{align*} 
+\end{center} 
+\end{document} 

--- a/specification.tex
+++ b/specification.tex
@@ -1,0 +1,16 @@
+\documentclass{article} \usepackage{amsmath} \begin{document} \begin{center}
+\begin{align*}
+\end{align*}Lowland Peat Overlap Constraints
+
+\begin{align*}((0.0258 * P_{lo}) + G) \leq 1\\((0.0258 * P_{lo}) + O) \leq 1\\\end{align*}Silvoarable Overlap Constraints
+
+\begin{align*}((0.3647 * S_{A}) + G) \leq 1\\((0.3647 * S_{A}) + O) \leq 1\\((0.4619 * S_{A}) + WL) \leq 1\\\end{align*}Silvopastoral Overlap Constraints
+
+\begin{align*}((0.3856 * S_{P}) + G) \leq 1\\((0.4883 * S_{P}) + WL) \leq 1\\((0.3856 * S_{P}) + O) \leq 1\\((0.8036 * S_{P}) + WP) \leq 1\\\end{align*}Woodland Overlap Constraints
+
+\begin{align*}((0.7503 * WL) + G) \leq 1\\((0.7503 * WL) + O) \leq 1\\(WL + (0.7218 * WP)) \leq 1.0986\\\end{align*}Wood Pasture Overlap Constraints
+
+\begin{align*}(WP + (1.3255 * G)) \leq 1.4433\\(WP + (1.3255 * O)) \leq 1.4433\\\end{align*}Grassland-Organic Overlap Constraints
+
+\begin{align*}(G + O) \leq 1\\
+\end{align*} \end{center} \end{document} 


### PR DESCRIPTION
This PR provides a way to enforce all the MiniLUSP constraints on the dashboard widgets.

It does so in a way that is extensible from a single definition of constraints in `constraints.py`, where constraints are given as a list of the form:
```
constraints = [
    "Lowland Peat Overlap Constraints"
  , (0.0258 * var("P_lo") + var("G")) <= 1
  , (0.0258 * var("P_lo") + var("O")) <= 1
...
```
This list can intersperse strings (which are ignored) with inequalities of the form `expression <= float` where the expression can be formed of addition, subtraction, floating point values, and `Expr("varname")` variable markers.

The `enforce_slider_constraints` callback in `dashboard.py` will automatically enforce these constraints. If changes to the constraints are needed, then only `constraints.py` needs modifying by expressing the inequalities.

This is implemented through a small embedded domain-specific language (eDSL) in `ConstraintSyntaxTrees.py` that represents the above constraints as syntax trees which can then evaluated to check the satisfiability `constraint.isSatisfied(model)` given a dictionary `model` mapping the variable names above to (of the form `Expr("varname")` to floats), and to balance a model `constraint.balance(model)`. 

The same representation can automatically generate a LaTeX specification of the constraints. Just uncomment the line:
```
# Uncomment me to generate LaTeX specification document when running the dashboard
# generateLatexSpecification(constraints)
```
in `constraints.py` and this will generate `specification.tex` when running the dashboard.